### PR TITLE
Log reader

### DIFF
--- a/load-balancer.tf
+++ b/load-balancer.tf
@@ -18,7 +18,7 @@ resource "aws_lb" "this" {
 }
 
 resource "aws_lb_listener" "http" {
-  count = var.enable_lb && !local.https_on ? 1 : 0
+  count = var.enable_lb && ! local.https_on ? 1 : 0
 
   load_balancer_arn = aws_lb.this[count.index].arn
   protocol          = "HTTP"

--- a/log-reader.tf
+++ b/log-reader.tf
@@ -1,0 +1,34 @@
+resource "aws_iam_user" "log_reader" {
+  name = "log-reader-${local.resource_name}"
+  tags = data.ns_workspace.this.tags
+}
+
+resource "aws_iam_access_key" "log_reader" {
+  user = aws_iam_user.log_reader.name
+}
+
+// The actions listed are necessary to read logs
+resource "aws_iam_user_policy" "log_reader" {
+  name   = "AllowReadLogs"
+  user   = aws_iam_user.log_reader.name
+  policy = data.aws_iam_policy_document.log_reader.json
+}
+
+data "aws_iam_policy_document" "log_reader" {
+  statement {
+    sid    = "AllowReadLogs"
+    effect = "Allow"
+
+    actions = [
+      "logs:Describe*",
+      "logs:Get*",
+      "logs:List*",
+      "logs:StartQuery",
+      "logs:StopQuery",
+      "logs:TestMetricFilter",
+      "logs:FilterLogEvents"
+    ]
+
+    resources = [aws_cloudwatch_log_group.this.arn]
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,9 +7,26 @@ output "cluster_arn" {
   description = "string ||| "
 }
 
+output "log_provider" {
+  value       = "cloudwatch"
+  description = "string ||| "
+}
+
 output "log_group_name" {
   value       = aws_cloudwatch_log_group.this.name
   description = "string ||| "
+}
+
+output "log_reader" {
+  value = {
+    name       = try(aws_iam_user.log_reader.name, "")
+    access_key = try(aws_iam_access_key.log_reader.id, "")
+    secret_key = try(aws_iam_access_key.log_reader.secret, "")
+  }
+
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to read logs from Cloudwatch."
+
+  sensitive = true
 }
 
 output "image_repo_name" {


### PR DESCRIPTION
This PR adds `log_provider=cloudwatch` and `log_reader` outputs.
This newly-introduced log reader is a user with explicit permissions to read cloudwatch logs.