### PR TITLE
Fix deployer

### DIFF
--- a/deployer.tf
+++ b/deployer.tf
@@ -1,0 +1,23 @@
+// ECS requires the user/role that initiates a deployment
+//   to have iam:PassRole access to the execution role
+// This grants the deployer user (created in the cluster module) access to this service's execution role
+// This is necessary for us to execute `nullstone deploy` on the CLI
+
+resource "aws_iam_user_policy_attachment" "deployer-execution" {
+  user       = local.deployer_name
+  policy_arn = aws_iam_policy.execution-pass-role.arn
+}
+
+resource "aws_iam_policy" "execution-pass-role" {
+  name_prefix = "${local.resource_name}-pass-role"
+  policy      = data.aws_iam_policy_document.deployer-execution.json
+}
+
+data "aws_iam_policy_document" "deployer-execution" {
+  statement {
+    side      = "AllowPassRoleToExecutionRole"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.execution.arn]
+  }
+}

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -34,3 +34,7 @@ locals {
 data "aws_ecs_cluster" "cluster" {
   cluster_name = data.ns_connection.cluster.outputs.cluster_name
 }
+
+locals {
+  deployer_name = data.ns_connection.cluster.outputs.deployer["name"]
+}

--- a/role.tf
+++ b/role.tf
@@ -34,13 +34,6 @@ locals {
 }
 
 data "aws_iam_policy_document" "execution" {
-  statement {
-    sid       = "AllowPassRoleToECS"
-    effect    = "Allow"
-    actions   = ["iam:PassRole"]
-    resources = [aws_iam_role.execution.arn]
-  }
-
   dynamic "statement" {
     for_each = local.secret_statement_resources
 


### PR DESCRIPTION
This PR fixes the following error that is hit when executing `nullstone deploy`.
This was introduced in v0.7.0 when the execution role was moved from the cluster into the service (in order to add secrets access).

```
error updating task with new image tag: operation error ECS: RegisterTaskDefinition, https response error StatusCode: 400, RequestID: d467eb20-dd06-4133-bf30-7a5ed3fe169b, api error AccessDeniedException: User: arn:aws:iam::772564115920:user/deployer-bronze-platypus-fxdrt is not authorized to perform: iam:PassRole on resource: arn:aws:iam::772564115920:role/execution-periwinkle-kangaroo-njjpo
```