### PR TITLE
Adding all secrets to secrets manager from capabilities

### DIFF
--- a/role.tf
+++ b/role.tf
@@ -28,8 +28,9 @@ resource "aws_iam_role_policy" "execution" {
 }
 
 locals {
-  secret_valueFroms          = [for secret in try(local.capabilities.secrets, []) : secret.valueFrom]
-  secret_statement_resources = length(local.secret_valueFroms) > 0 ? [local.secret_valueFroms] : []
+  // These are used to generate an IAM policy statement to allow the app to read the secrets
+  secret_arns                = [for as in aws_secretsmanager_secret.app_secret : as.arn]
+  secret_statement_resources = length(local.secret_arns) > 0 ? [local.secret_arns] : []
 }
 
 data "aws_iam_policy_document" "execution" {

--- a/secrets.tf
+++ b/secrets.tf
@@ -5,6 +5,8 @@ locals {
   // This is because the name of secrets isn't computed in the modules; only the secret value
   secret_keys = toset(nonsensitive([for secret in local.capabilities.secrets : secret["name"]]))
   cap_secrets = { for secret in local.capabilities.secrets : secret["name"] => secret["value"] }
+
+  // app_secrets is prepared in the form [{ name = "", valueFrom = "<arn>" }, ...] for injection into ECS services
   app_secrets = [for key in local.secret_keys : { name = key, valueFrom = aws_secretsmanager_secret.app_secret[key].arn }]
 }
 

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,0 +1,23 @@
+locals {
+  // We use `local.secret_keys` to create secret resources
+  // If we used `length(local.capabilities.secrets)`,
+  //   terraform would complain about not knowing count of the resource until after apply
+  // This is because the name of secrets isn't computed in the modules; only the secret value
+  secret_keys = toset(nonsensitive([for secret in local.capabilities.secrets : secret["name"]]))
+  cap_secrets = { for secret in local.capabilities.secrets : secret["name"] => secret["value"] }
+  app_secrets = [for key in local.secret_keys : { name = key, valueFrom = aws_secretsmanager_secret.app_secret[key].arn }]
+}
+
+resource "aws_secretsmanager_secret" "app_secret" {
+  for_each = local.secret_keys
+
+  name = "${local.resource_name}/${each.value}"
+  tags = data.ns_workspace.this.tags
+}
+
+resource "aws_secretsmanager_secret_version" "app_secret" {
+  for_each = local.secret_keys
+
+  secret_id     = aws_secretsmanager_secret.app_secret[each.value].id
+  secret_string = local.cap_secrets[each.value]
+}

--- a/task.tf
+++ b/task.tf
@@ -23,7 +23,7 @@ locals {
     ]
 
     environment = concat(local.env_vars, try(local.capabilities.env, []))
-    secrets     = try(local.capabilities.secrets, [])
+    secrets     = local.app_secrets
 
     cpu               = var.service_cpu
     memoryReservation = var.service_memory


### PR DESCRIPTION
This PR changes the contract of secrets for services.
Instead of the capability adding to the secrets manager, the service is responsible for generating secrets and stuffing the values.
The service module is also responsible for injecting secrets in via env vars.

This new contract does not increase exposure of the secret values -- they are already stored within the state file. They remain limited to the state file alone.