### PR TITLE
This PR merges aws-fargate-worker into this module

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -76,8 +76,8 @@ output "service_security_group_id" {
 }
 
 locals {
-  additional_private_urls = [
-    "http://${aws_service_discovery_service.this.name}.${local.service_domain}:${var.service_port}"
+  additional_private_urls = var.service_port == 0 ? [] : [
+    "http://${aws_service_discovery_service.this[0].name}.${local.service_domain}:${var.service_port}"
   ]
   additional_public_urls = []
 }

--- a/security-group.tf
+++ b/security-group.tf
@@ -20,6 +20,8 @@ resource "aws_security_group_rule" "this-http-from-private-subnets" {
   from_port         = var.service_port
   to_port           = var.service_port
   cidr_blocks       = data.ns_connection.network.outputs.private_cidrs
+
+  count = var.service_port == 0 ? 0 : 1
 }
 
 // TODO: Drop this once we have a better way of reaching via bastion
@@ -30,6 +32,8 @@ resource "aws_security_group_rule" "this-http-from-public-subnets" {
   from_port         = var.service_port
   to_port           = var.service_port
   cidr_blocks       = data.ns_connection.network.outputs.public_cidrs
+
+  count = var.service_port == 0 ? 0 : 1
 }
 
 resource "aws_security_group_rule" "this-http-to-private-subnets" {

--- a/service.tf
+++ b/service.tf
@@ -1,7 +1,7 @@
 resource "aws_ecs_service" "this" {
   name            = data.ns_workspace.this.block_name
   cluster         = data.aws_ecs_cluster.cluster.arn
-  desired_count   = 1
+  desired_count   = var.service_count
   task_definition = aws_ecs_task_definition.this.arn
   launch_type     = "FARGATE"
 

--- a/service.tf
+++ b/service.tf
@@ -11,8 +11,12 @@ resource "aws_ecs_service" "this" {
     security_groups  = [aws_security_group.this.id]
   }
 
-  service_registries {
-    registry_arn = aws_service_discovery_service.this.arn
+  dynamic "service_registries" {
+    for_each = aws_service_discovery_service.this
+
+    content {
+      registry_arn = service_registries.value.arn
+    }
   }
 
   dynamic "load_balancer" {
@@ -27,6 +31,8 @@ resource "aws_ecs_service" "this" {
 }
 
 resource "aws_service_discovery_service" "this" {
+  count = var.service_port == 0 ? 0 : 1
+
   name = data.ns_workspace.this.block_name
 
   dns_config {

--- a/task.tf
+++ b/task.tf
@@ -46,6 +46,7 @@ resource "aws_ecs_task_definition" "this" {
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.execution.arn
+  depends_on               = [aws_iam_role_policy.execution]
   container_definitions    = jsonencode([local.container_definition])
   tags                     = data.ns_workspace.this.tags
 }

--- a/task.tf
+++ b/task.tf
@@ -18,7 +18,7 @@ locals {
     name      = data.ns_workspace.this.block_name
     image     = "${local.service_image}:${local.app_version}"
     essential = true
-    portMappings = [
+    portMappings = var.service_port == 0 ? [] : [
       {
         protocol      = "tcp"
         containerPort = var.service_port

--- a/variables.tf
+++ b/variables.tf
@@ -52,5 +52,6 @@ variable "service_port" {
 The port that the service is listening on.
 This is set to port 80 by default; however, if the service in the container is a non-root user,
 the service will fail due to bind due to permission errors.
+Specify 0 to disable network connectivity to this container.
 EOF
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "service_count" {
+  type    = number
+  default = 1
+}
+
 variable "service_cpu" {
   type        = number
   default     = 256


### PR DESCRIPTION
Ensure task_definition doesn't get created until after execution role is fully configured.

Added `var.service_count`.

When `var.service_port = 0:
- Disable `{service}.service` DNS record from being added
- Disable ingress rules
- Remove port mappings from service