### PR TITLE
Sidecars

### DIFF
--- a/capabilities.tf
+++ b/capabilities.tf
@@ -46,7 +46,7 @@ locals {
         options = {
           "awslogs-region"        = data.aws_region.this.name
           "awslogs-group"         = module.logs.name
-          "awslogs-stream-prefix" = local.main_container_name
+          "awslogs-stream-prefix" = local.block_name
         }
       }
     ]

--- a/capabilities.tf
+++ b/capabilities.tf
@@ -59,5 +59,20 @@ locals {
         path = "/path/on/main/disk"
       }
     ]
+
+    // sidecars allow capabilities to attach additional containers to the service
+    sidecars = [
+      {
+        name         = ""
+        image        = ""
+        essential    = false
+        portMappings = [{ protocol = "tcp", containerPort = 0, hostPort = 0 }]
+        environment  = [{ name = "", value = "" }]
+        secrets      = [{ name = "", valueFrom = "" }]
+        mountPoints  = [{ sourceVolume = "", containerPath = "" }]
+        volumesFrom  = [{ sourceContainer = "" }]
+        dependsOn    = [{ containerName = "", condition = "" }]
+      }
+    ]
   }
 }

--- a/capabilities.tf
+++ b/capabilities.tf
@@ -50,5 +50,14 @@ locals {
         }
       }
     ]
+
+    // capabilities can attach mount points to pull/push data from/to the main container
+    // The name of each mount point will be added to the task as a volume, then mounted in the main container
+    mount_points = [
+      {
+        name = "volume-name"
+        path = "/path/on/main/disk"
+      }
+    ]
   }
 }

--- a/capabilities.tf
+++ b/capabilities.tf
@@ -46,7 +46,7 @@ locals {
         options = {
           "awslogs-region"        = data.aws_region.this.name
           "awslogs-group"         = module.logs.name
-          "awslogs-stream-prefix" = data.ns_workspace.this.env_name
+          "awslogs-stream-prefix" = local.main_container_name
         }
       }
     ]

--- a/capabilities.tf.tmpl
+++ b/capabilities.tf.tmpl
@@ -10,6 +10,7 @@ module "cap_{{ .Id }}" {
 
   app_metadata = {
     security_group_id = aws_security_group.this.id
+    main_container    = local.main_container_name
   }
 
   {{- range $key, $value := .Variables }}

--- a/capabilities.tf.tmpl
+++ b/capabilities.tf.tmpl
@@ -11,6 +11,7 @@ module "cap_{{ .Id }}" {
   app_metadata = {
     security_group_id = aws_security_group.this.id
     main_container    = local.main_container_name
+    service_port      = var.service_port
   }
 
   {{- range $key, $value := .Variables }}

--- a/name.tf
+++ b/name.tf
@@ -7,5 +7,6 @@ resource "random_string" "resource_suffix" {
 }
 
 locals {
+  block_name    = data.ns_workspace.this.block_name
   resource_name = "${data.ns_workspace.this.block_ref}-${random_string.resource_suffix.result}"
 }

--- a/secrets.tf
+++ b/secrets.tf
@@ -3,7 +3,7 @@ locals {
   // If we used `length(local.capabilities.secrets)`,
   //   terraform would complain about not knowing count of the resource until after apply
   // This is because the name of secrets isn't computed in the modules; only the secret value
-  raw_secret_keys = [ for secret in lookup(local.capabilities, "secrets", []) : secret["name"] ]
+  raw_secret_keys = [for secret in lookup(local.capabilities, "secrets", []) : secret["name"]]
   secret_keys     = can(nonsensitive(local.raw_secret_keys)) ? toset(nonsensitive(local.raw_secret_keys)) : toset(local.raw_secret_keys)
   cap_secrets     = { for secret in try(local.capabilities.secrets, []) : secret["name"] => secret["value"] }
 

--- a/service.tf
+++ b/service.tf
@@ -1,5 +1,5 @@
 resource "aws_ecs_service" "this" {
-  name            = data.ns_workspace.this.block_name
+  name            = local.block_name
   cluster         = data.aws_ecs_cluster.cluster.arn
   desired_count   = var.service_count
   task_definition = aws_ecs_task_definition.this.arn
@@ -23,7 +23,7 @@ resource "aws_ecs_service" "this" {
     for_each = lookup(local.capabilities, "load_balancers", [])
 
     content {
-      container_name   = data.ns_workspace.this.block_name
+      container_name   = local.block_name
       container_port   = load_balancer.value.port
       target_group_arn = load_balancer.value.target_group_arn
     }
@@ -33,7 +33,7 @@ resource "aws_ecs_service" "this" {
 resource "aws_service_discovery_service" "this" {
   count = var.service_port == 0 ? 0 : 1
 
-  name = data.ns_workspace.this.block_name
+  name = local.block_name
 
   dns_config {
     namespace_id = data.ns_connection.network.outputs.service_discovery_id

--- a/sidecars.tf
+++ b/sidecars.tf
@@ -1,0 +1,18 @@
+locals {
+  sidecars = lookup(local.capabilities, "sidecars", [])
+
+  addl_container_defs = [for s in local.sidecars : merge(s, {
+    name         = s.name
+    image        = s.image
+    essential    = lookup(s, "essential", false)
+    portMappings = lookup(s, "portMappings", [])
+    environment  = lookup(s, "environment", [])
+    secrets      = lookup(s, "secrets", [])
+    mountPoints  = lookup(s, "mountPoints", [])
+    volumesFrom  = lookup(s, "volumesFrom", [])
+    healthCheck  = lookup(s, "healthCheck", {})
+    dependsOn    = lookup(s, "dependsOn", [])
+
+    logConfiguration = local.log_configurations[0]
+  })]
+}

--- a/task.tf
+++ b/task.tf
@@ -3,6 +3,8 @@ locals {
     NULLSTONE_ENV = data.ns_workspace.this.env_name
   })
 
+  main_container_name = data.ns_workspace.this.block_name
+
   env_vars = [for k, v in merge(local.standard_env_vars, var.service_env_vars) : { name = k, value = v }]
 
   log_configurations = concat(try(local.capabilities.log_configurations, []), [{
@@ -10,12 +12,12 @@ locals {
     options = {
       "awslogs-region"        = data.aws_region.this.name
       "awslogs-group"         = module.logs.name
-      "awslogs-stream-prefix" = data.ns_workspace.this.env_name
+      "awslogs-stream-prefix" = local.main_container_name
     }
   }])
 
   container_definition = {
-    name      = data.ns_workspace.this.block_name
+    name      = local.main_container_name
     image     = "${local.service_image}:${local.app_version}"
     essential = true
     portMappings = var.service_port == 0 ? [] : [

--- a/task.tf
+++ b/task.tf
@@ -3,7 +3,7 @@ locals {
     NULLSTONE_ENV = data.ns_workspace.this.env_name
   })
 
-  main_container_name = data.ns_workspace.this.block_name
+  main_container_name = "main"
 
   env_vars = [for k, v in merge(local.standard_env_vars, var.service_env_vars) : { name = k, value = v }]
 
@@ -12,7 +12,7 @@ locals {
     options = {
       "awslogs-region"        = data.aws_region.this.name
       "awslogs-group"         = module.logs.name
-      "awslogs-stream-prefix" = local.main_container_name
+      "awslogs-stream-prefix" = local.block_name
     }
   }])
 

--- a/task.tf
+++ b/task.tf
@@ -34,7 +34,7 @@ locals {
     cpu               = var.service_cpu
     memoryReservation = var.service_memory
 
-    mountPoints = []
+    mountPoints = local.mount_points
     volumesFrom = []
 
     logConfiguration = local.log_configurations[0]
@@ -51,4 +51,12 @@ resource "aws_ecs_task_definition" "this" {
   depends_on               = [aws_iam_role_policy.execution]
   container_definitions    = jsonencode([local.container_definition])
   tags                     = data.ns_workspace.this.tags
+
+  dynamic "volume" {
+    for_each = local.volumes
+
+    content {
+      name = volume.key
+    }
+  }
 }

--- a/task.tf
+++ b/task.tf
@@ -46,7 +46,7 @@ resource "aws_ecs_task_definition" "this" {
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.execution.arn
   depends_on               = [aws_iam_role_policy.execution]
-  container_definitions    = jsonencode([local.container_definition])
+  container_definitions    = jsonencode(concat([local.container_definition], local.addl_container_defs))
   tags                     = data.ns_workspace.this.tags
 
   dynamic "volume" {

--- a/task.tf
+++ b/task.tf
@@ -31,9 +31,6 @@ locals {
     environment = concat(local.env_vars, try(local.capabilities.env, []))
     secrets     = local.app_secrets
 
-    cpu               = var.service_cpu
-    memoryReservation = var.service_memory
-
     mountPoints = local.mount_points
     volumesFrom = []
 

--- a/volumes.tf
+++ b/volumes.tf
@@ -1,0 +1,6 @@
+locals {
+  cap_mount_points = lookup(local.capabilities, "mount_points", [])
+
+  mount_points = [for mp in local.cap_mount_points : { sourceVolume = mp.name, containerPath = mp.path }]
+  volumes      = { for mp in local.cap_mount_points : mp.name => "" }
+}


### PR DESCRIPTION
This PR adds support for `sidecars` and `mount_points` from capabilities.
This required the app to send `main_container` (main container name) and `service_port` (as specified by user in vars) to each capability via `app_metadata`.

A `sidecar` stands up an additional container definition inside the task definition.
This sidecar has the ability to take over the service port `owns_service_port`. 
This relays the `service_port` to the sidecar instead of listening on the main container.


A `mount_point` from a capability creates a volume in the task definition.