### PR TITLE
C536 Modules in needs-destroyed are not considered for cap outputs

### DIFF
--- a/capabilities.tf.tmpl
+++ b/capabilities.tf.tmpl
@@ -4,7 +4,7 @@ provider "ns" {
   alias         = "cap_{{ .Id }}"
 }
 
-module "cap_{{ .Id }}" {
+module "{{ .TfModuleName }}" {
   source  = "{{ .Source }}/any"
   {{ if (ne .SourceVersion "latest") }}version = "{{ .SourceVersion }}"{{ end }}
 
@@ -30,6 +30,10 @@ module "caps" {
 }
 
 locals {
-  modules       = [{{ range $index, $element := .ExceptNeedsDestroyed }}{{ if $index }}, {{ end }}module.cap_{{ $element.Id }}{{ end }}]
+  modules       = [
+{{- range $index, $element := .ExceptNeedsDestroyed.TfModuleAddrs -}}
+{{ if $index }}, {{ end }}{{ $element }}
+{{- end -}}
+]
   capabilities  = module.caps.outputs
 }

--- a/capabilities.tf.tmpl
+++ b/capabilities.tf.tmpl
@@ -30,6 +30,6 @@ module "caps" {
 }
 
 locals {
-  modules       = [{{ range $index, $element := . }}{{ if $index }}, {{ end }}module.cap_{{ $element.Id }}{{ end }}]
+  modules       = [{{ range $index, $element := .ExceptNeedsDestroyed }}{{ if $index }}, {{ end }}module.cap_{{ $element.Id }}{{ end }}]
   capabilities  = module.caps.outputs
 }


### PR DESCRIPTION
This PR alters capability code generation and relies on https://github.com/nullstone-io/nullfire/pull/72

Capabilities that are marked `NeedsDestroyed` are not included when merging outputs to connect capabilities with the fargate service.