### PR TITLE
Moving deployer user into fargate service, adding to deployers group

### DIFF
--- a/deployer.tf
+++ b/deployer.tf
@@ -1,19 +1,30 @@
 // ECS requires the user/role that initiates a deployment
 //   to have iam:PassRole access to the execution role
-// This grants the deployer user (created in the cluster module) access to this service's execution role
+// This grants the deployer user access to this service's execution role
 // This is necessary for us to execute `nullstone deploy` on the CLI
 
-resource "aws_iam_user_policy_attachment" "deployer-execution" {
-  user       = local.deployer_name
-  policy_arn = aws_iam_policy.execution-pass-role.arn
+resource "aws_iam_user" "deployer" {
+  name = "deployer-${local.resource_name}"
+  tags = local.tags
 }
 
-resource "aws_iam_policy" "execution-pass-role" {
-  name_prefix = "${local.resource_name}-pass-role"
-  policy      = data.aws_iam_policy_document.execution-pass-role.json
+resource "aws_iam_access_key" "deployer" {
+  user = aws_iam_user.deployer.name
 }
 
-data "aws_iam_policy_document" "execution-pass-role" {
+// Add deployer to deployers group defined in the cluster
+// This allows the deployer user to perform common operations on the cluster
+resource "aws_iam_user_group_membership" "deployers" {
+  user   = aws_iam_user.deployer.name
+  groups = [local.deployers_name]
+}
+
+resource "aws_iam_user_policy" "deployer" {
+  user   = aws_iam_user.deployer.name
+  policy = data.aws_iam_policy_document.deployer.json
+}
+
+data "aws_iam_policy_document" "deployer" {
   statement {
     sid     = "AllowPassRoleToServiceRoles"
     effect  = "Allow"

--- a/execution.tf
+++ b/execution.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "execution" {
   name               = "execution-${local.resource_name}"
-  tags               = data.ns_workspace.this.tags
+  tags               = local.tags
   assume_role_policy = data.aws_iam_policy_document.execution-assume.json
 }
 

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -20,12 +20,14 @@ data "ns_connection" "network" {
   via  = data.ns_connection.cluster.name
 }
 
-data "aws_ecs_cluster" "cluster" {
-  cluster_name = data.ns_connection.cluster.outputs.cluster_name
-}
-
 locals {
-  deployer_name        = data.ns_connection.cluster.outputs.deployer["name"]
+  tags                 = data.ns_workspace.this.tags
+  cluster_name         = data.ns_connection.cluster.outputs.cluster_name
+  deployers_name       = data.ns_connection.cluster.outputs.deployers_name
   service_domain       = data.ns_connection.network.outputs.service_discovery_name
   service_discovery_id = data.ns_connection.network.outputs.service_discovery_id
+}
+
+data "aws_ecs_cluster" "cluster" {
+  cluster_name = local.cluster_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,6 +45,18 @@ output "image_pusher" {
   sensitive = true
 }
 
+output "deployer" {
+  value = {
+    name       = aws_iam_user.deployer.name
+    access_key = aws_iam_access_key.deployer.id
+    secret_key = aws_iam_access_key.deployer.secret
+  }
+
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to deploy ECS services."
+
+  sensitive = true
+}
+
 output "service_image" {
   value       = "${local.service_image}:${local.app_version}"
   description = "string ||| "


### PR DESCRIPTION
This PR creates a deployer user instead of using the deployer user from the cluster.
The deployer user is added to the newly-created deployer group in the cluster.