### PR TITLE
C808 compliance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Run Bridgecrew
+        id: Bridgecrew
+        uses: bridgecrewio/bridgecrew-action@master
+        with:
+          api-key: ${{ secrets.BC_API_KEY }}
+
       # Package files into tgz
       - name: Package
         run: tar -cvzf module.tgz *.tf *.tf.tmpl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.12.0 (Unreleased)
+
+* Enabled in-transit encryption for EFS volumes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # 0.12.0 (Unreleased)
 
 * Enabled in-transit encryption for EFS volumes.
+* Using CMK (customer-managed key) when encrypting cloudwatch logs, secrets, and image repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,5 @@
 
 * Enabled in-transit encryption for EFS volumes.
 * Using CMK (customer-managed key) when encrypting cloudwatch logs, secrets, and image repository.
+* Enabled image scanning when an image is pushed to the image repository.
+* Enabled tag immutability on the image repository. Can only push an image once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.12.0 (Unreleased)
+# 0.12.0 (Apr 21, 2022)
 
 * Enabled in-transit encryption for EFS volumes.
 * Using CMK (customer-managed key) when encrypting cloudwatch logs, secrets, and image repository.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Nullstone Block standing up an AWS Fargate container service using ECR and configured to emit to AWS CloudWatch Logs.
 
+## Security & Compliance
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+[![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-fargate-service/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-fargate-service&benchmark=INFRASTRUCTURE+SECURITY)
+[![CIS AWS V1.3](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-fargate-service/cis_aws_13)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-fargate-service&benchmark=CIS+AWS+V1.3)
+[![PCI-DSS V3.2](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-fargate-service/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-fargate-service&benchmark=PCI-DSS+V3.2)
+[![NIST-800-53](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-fargate-service/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-fargate-service&benchmark=NIST-800-53)
+[![ISO27001](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-fargate-service/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-fargate-service&benchmark=ISO27001)
+[![SOC2](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-fargate-service/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-fargate-service&benchmark=SOC2)
+[![HIPAA](https://www.bridgecrew.cloud/badges/github/nullstone-modules/aws-fargate-service/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=nullstone-modules%2Faws-fargate-service&benchmark=HIPAA)
+
 ## Inputs
 
 - `service_cpu: number`
@@ -16,6 +28,12 @@ Nullstone Block standing up an AWS Fargate container service using ECR and confi
   - The docker image to deploy for this service.
   - The version from the nullstone application will be used as the image tag.
   - Default: `""` - An ECR repo will be created and used.
+- `service_port: number`
+  - The port that the service is listening on.
+    This is set to port 80 by default; however, if the service in the container is a non-root user,
+    the service will fail due to bind due to permission errors.
+    Specify 0 to disable network connectivity to this container.
+  - Default: `80`
 - `service_env_vars: map(string)`
   - Map of environment variables to inject into the service
 

--- a/aws.tf
+++ b/aws.tf
@@ -1,1 +1,2 @@
 data "aws_region" "this" {}
+data "aws_caller_identity" "current" {}

--- a/deployer.tf
+++ b/deployer.tf
@@ -20,6 +20,7 @@ resource "aws_iam_user_group_membership" "deployers" {
 }
 
 resource "aws_iam_user_policy" "deployer" {
+  #bridgecrew:skip=CKV_AWS_40: Skipping `IAM policies attached only to groups or roles reduces management complexity`; Adding a role or group would increase complexity
   user   = aws_iam_user.deployer.name
   policy = data.aws_iam_policy_document.deployer.json
 }

--- a/encryption.tf
+++ b/encryption.tf
@@ -7,10 +7,12 @@ resource "aws_kms_key" "this" {
 }
 
 data "aws_iam_policy_document" "encryption_key" {
+  #bridgecrew:skip=CKV_AWS_109: Skipping "Permissions management without constraints". False positive as this is attached as a key policy and is implicitly constrained by the key.
+  #bridgecrew:skip=CKV_AWS_111: Skipping "Write IAM policies without constraints". False positive as this is attached as a key policy and is implicitly constrained by the key.
   statement {
     sid       = "Enable IAM User permissions"
     effect    = "Allow"
-    resources = [aws_kms_key.this.arn]
+    resources = ["*"]
     actions   = ["kms:*"]
 
     principals {
@@ -22,7 +24,7 @@ data "aws_iam_policy_document" "encryption_key" {
   statement {
     sid       = "Enable Cloudwatch Log encryption"
     effect    = "Allow"
-    resources = [aws_kms_key.this.arn]
+    resources = ["*"]
     actions = [
       "kms:Encrypt*",
       "kms:Decrypt*",

--- a/encryption.tf
+++ b/encryption.tf
@@ -1,0 +1,55 @@
+resource "aws_kms_key" "this" {
+  description         = "Encryption key for service ${local.resource_name}"
+  enable_key_rotation = true
+  is_enabled          = true
+  tags                = local.tags
+  policy              = data.aws_iam_policy_document.encryption_key.json
+}
+
+data "aws_iam_policy_document" "encryption_key" {
+  #bridgecrew:skip=CKV_AWS_109: Skipping "Permissions management without constraints". False positive as this is attached as a key policy and is implicitly constrained by the key.
+  #bridgecrew:skip=CKV_AWS_111: Skipping "Write IAM policies without constraints". False positive as this is attached as a key policy and is implicitly constrained by the key.
+  statement {
+    sid       = "Enable IAM User permissions"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  statement {
+    sid = "Enable ECR image encryption"
+  }
+
+  statement {
+    sid = "Enable "
+  }
+
+  statement {
+    sid       = "Enable Cloudwatch Log encryption"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${data.aws_region.this.name}.amazonaws.com"]
+    }
+
+    condition {
+      test     = "ArnEquals"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+      values   = ["arn:aws:logs:${data.aws_region.this.name}:${data.aws_caller_identity.current.account_id}:*"]
+    }
+  }
+}

--- a/encryption.tf
+++ b/encryption.tf
@@ -1,3 +1,8 @@
+resource "aws_kms_alias" "this" {
+  name          = "alias/${local.resource_name}"
+  target_key_id = aws_kms_key.this.id
+}
+
 resource "aws_kms_key" "this" {
   description         = "Encryption key for service ${local.resource_name}"
   enable_key_rotation = true

--- a/encryption.tf
+++ b/encryption.tf
@@ -7,12 +7,10 @@ resource "aws_kms_key" "this" {
 }
 
 data "aws_iam_policy_document" "encryption_key" {
-  #bridgecrew:skip=CKV_AWS_109: Skipping "Permissions management without constraints". False positive as this is attached as a key policy and is implicitly constrained by the key.
-  #bridgecrew:skip=CKV_AWS_111: Skipping "Write IAM policies without constraints". False positive as this is attached as a key policy and is implicitly constrained by the key.
   statement {
     sid       = "Enable IAM User permissions"
     effect    = "Allow"
-    resources = ["*"]
+    resources = [aws_kms_key.this.arn]
     actions   = ["kms:*"]
 
     principals {
@@ -22,17 +20,9 @@ data "aws_iam_policy_document" "encryption_key" {
   }
 
   statement {
-    sid = "Enable ECR image encryption"
-  }
-
-  statement {
-    sid = "Enable "
-  }
-
-  statement {
     sid       = "Enable Cloudwatch Log encryption"
     effect    = "Allow"
-    resources = ["*"]
+    resources = [aws_kms_key.this.arn]
     actions = [
       "kms:Encrypt*",
       "kms:Decrypt*",

--- a/logs.tf
+++ b/logs.tf
@@ -5,7 +5,7 @@ module "logs" {
   tags              = local.tags
   enable_log_reader = true
   retention_in_days = 90
-  kms_key_arn       = aws_kms_key.this.arn
+  kms_key_arn       = aws_kms_alias.this.arn
 }
 
 locals {

--- a/logs.tf
+++ b/logs.tf
@@ -2,8 +2,10 @@ module "logs" {
   source = "nullstone-modules/logs/aws"
 
   name              = local.resource_name
-  tags              = data.ns_workspace.this.tags
+  tags              = local.tags
   enable_log_reader = true
+  retention_in_days = 90
+  kms_key_arn       = aws_kms_key.this.arn
 }
 
 locals {

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -8,6 +8,7 @@ terraform {
 
 data "ns_workspace" "this" {}
 
+// Generate a random suffix to ensure uniqueness of resources
 resource "random_string" "resource_suffix" {
   length  = 5
   lower   = true
@@ -34,6 +35,9 @@ data "ns_connection" "network" {
 }
 
 locals {
+  vpc_id               = data.ns_connection.network.outputs.vpc_id
+  private_cidrs        = data.ns_connection.network.outputs.private_cidrs
+  public_cidrs         = data.ns_connection.network.outputs.public_cidrs
   cluster_name         = data.ns_connection.cluster.outputs.cluster_name
   deployers_name       = data.ns_connection.cluster.outputs.deployers_name
   service_domain       = data.ns_connection.network.outputs.service_discovery_name

--- a/pusher.tf
+++ b/pusher.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_user" "image_pusher" {
   name = "image-pusher-${local.resource_name}"
-  tags = data.ns_workspace.this.tags
+  tags = local.tags
 
   count = var.service_image == "" ? 1 : 0
 }
@@ -11,8 +11,8 @@ resource "aws_iam_access_key" "image_pusher" {
   count = var.service_image == "" ? 1 : 0
 }
 
-// The actions listed are necessary to perform actions to push ECR images
 resource "aws_iam_user_policy" "image_pusher" {
+  #bridgecrew:skip=CKV_AWS_40: Skipping `IAM policies attached only to groups or roles reduces management complexity`; Adding a role or group would increase complexity
   name   = "AllowECRPush"
   user   = aws_iam_user.image_pusher[count.index].name
   policy = data.aws_iam_policy_document.image_pusher.json
@@ -25,6 +25,7 @@ data "aws_iam_policy_document" "image_pusher" {
     sid    = "AllowPushPull"
     effect = "Allow"
 
+    // The actions listed are necessary to perform actions to push ECR images
     actions = [
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchGetImage",

--- a/repository.tf
+++ b/repository.tf
@@ -7,8 +7,13 @@ locals {
 // This is a bit odd - we're creating a repository for every environment
 // We need to find a better way to do this
 resource "aws_ecr_repository" "this" {
-  name = local.resource_name
-  tags = data.ns_workspace.this.tags
+  name                 = local.resource_name
+  tags                 = local.tags
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.this.arn
+  }
 
   count = var.service_image == "" ? 1 : 0
 }

--- a/repository.tf
+++ b/repository.tf
@@ -17,7 +17,7 @@ resource "aws_ecr_repository" "this" {
 
   encryption_configuration {
     encryption_type = "KMS"
-    kms_key         = aws_kms_key.this.arn
+    kms_key         = aws_kms_alias.this.arn
   }
 
   count = var.service_image == "" ? 1 : 0

--- a/repository.tf
+++ b/repository.tf
@@ -9,6 +9,11 @@ locals {
 resource "aws_ecr_repository" "this" {
   name                 = local.resource_name
   tags                 = local.tags
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
 
   encryption_configuration {
     encryption_type = "KMS"

--- a/secrets.tf
+++ b/secrets.tf
@@ -14,8 +14,9 @@ locals {
 resource "aws_secretsmanager_secret" "app_secret" {
   for_each = local.secret_keys
 
-  name = "${local.resource_name}/${each.value}"
-  tags = data.ns_workspace.this.tags
+  name       = "${local.resource_name}/${each.value}"
+  tags       = local.tags
+  kms_key_id = aws_kms_key.this.arn
 }
 
 resource "aws_secretsmanager_secret_version" "app_secret" {

--- a/secrets.tf
+++ b/secrets.tf
@@ -16,7 +16,7 @@ resource "aws_secretsmanager_secret" "app_secret" {
 
   name       = "${local.resource_name}/${each.value}"
   tags       = local.tags
-  kms_key_id = aws_kms_key.this.arn
+  kms_key_id = aws_kms_alias.this.arn
 }
 
 resource "aws_secretsmanager_secret_version" "app_secret" {

--- a/security-group.tf
+++ b/security-group.tf
@@ -1,10 +1,12 @@
 resource "aws_security_group" "this" {
-  name   = local.resource_name
-  vpc_id = data.ns_connection.network.outputs.vpc_id
-  tags   = merge(data.ns_workspace.this.tags, { Name = local.resource_name })
+  name        = local.resource_name
+  vpc_id      = local.vpc_id
+  tags        = merge(local.tags, { Name = local.resource_name })
+  description = "Managed by Terraform"
 }
 
 resource "aws_security_group_rule" "this-dns-tcp-to-world" {
+  description       = "Allow service to communicate with any nameserver over TCP"
   security_group_id = aws_security_group.this.id
   type              = "egress"
   protocol          = "tcp"
@@ -14,6 +16,7 @@ resource "aws_security_group_rule" "this-dns-tcp-to-world" {
 }
 
 resource "aws_security_group_rule" "this-dns-udp-to-world" {
+  description       = "Allow service to communicate with any nameserver over UDP"
   security_group_id = aws_security_group.this.id
   type              = "egress"
   protocol          = "udp"
@@ -23,6 +26,7 @@ resource "aws_security_group_rule" "this-dns-udp-to-world" {
 }
 
 resource "aws_security_group_rule" "this-https-to-world" {
+  description       = "Allow service to communicate with any server over HTTPS"
   security_group_id = aws_security_group.this.id
   type              = "egress"
   protocol          = "tcp"
@@ -32,33 +36,36 @@ resource "aws_security_group_rule" "this-https-to-world" {
 }
 
 resource "aws_security_group_rule" "this-http-from-private-subnets" {
+  description       = "Allow any service on this network (in private subnets) to communicate with this service on the service's port"
   security_group_id = aws_security_group.this.id
   type              = "ingress"
   protocol          = "tcp"
   from_port         = var.service_port
   to_port           = var.service_port
-  cidr_blocks       = data.ns_connection.network.outputs.private_cidrs
+  cidr_blocks       = local.private_cidrs
 
   count = var.service_port == 0 ? 0 : 1
 }
 
 // TODO: Drop this once we have a better way of reaching via bastion
 resource "aws_security_group_rule" "this-http-from-public-subnets" {
+  description       = "Allow any service on this network (in public subnets) to communicate with this service on the service's port"
   security_group_id = aws_security_group.this.id
   type              = "ingress"
   protocol          = "tcp"
   from_port         = var.service_port
   to_port           = var.service_port
-  cidr_blocks       = data.ns_connection.network.outputs.public_cidrs
+  cidr_blocks       = local.public_cidrs
 
   count = var.service_port == 0 ? 0 : 1
 }
 
 resource "aws_security_group_rule" "this-http-to-private-subnets" {
+  description       = "Allow this service to communicate with other services on the network over HTTP"
   security_group_id = aws_security_group.this.id
   type              = "egress"
   protocol          = "tcp"
   from_port         = 80
   to_port           = 80
-  cidr_blocks       = data.ns_connection.network.outputs.private_cidrs
+  cidr_blocks       = local.private_cidrs
 }

--- a/security-group.tf
+++ b/security-group.tf
@@ -36,7 +36,7 @@ resource "aws_security_group_rule" "this-https-to-world" {
 }
 
 resource "aws_security_group_rule" "this-http-from-private-subnets" {
-  description       = "Allow any service on this network (in private subnets) to communicate with this service on the service's port"
+  description       = "Allow any service on this network in private subnets to communicate with this service on the service port"
   security_group_id = aws_security_group.this.id
   type              = "ingress"
   protocol          = "tcp"
@@ -49,7 +49,7 @@ resource "aws_security_group_rule" "this-http-from-private-subnets" {
 
 // TODO: Drop this once we have a better way of reaching via bastion
 resource "aws_security_group_rule" "this-http-from-public-subnets" {
-  description       = "Allow any service on this network (in public subnets) to communicate with this service on the service's port"
+  description       = "Allow any service on this network in public subnets to communicate with this service on the service port"
   security_group_id = aws_security_group.this.id
   type              = "ingress"
   protocol          = "tcp"

--- a/task.tf
+++ b/task.tf
@@ -56,8 +56,10 @@ resource "aws_ecs_task_definition" "this" {
         for_each = length(volume.value.efs_volume) > 0 ? tomap({ "1" = jsondecode(volume.value.efs_volume) }) : tomap({})
 
         content {
-          file_system_id = efs_volume_configuration.value.file_system_id
-          root_directory = efs_volume_configuration.value.root_directory
+          file_system_id          = efs_volume_configuration.value.file_system_id
+          root_directory          = efs_volume_configuration.value.root_directory
+          transit_encryption      = "ENABLED"
+          transit_encryption_port = 2999
         }
       }
     }

--- a/upgrades/v0.12.md
+++ b/upgrades/v0.12.md
@@ -1,0 +1,48 @@
+# Announcement for v0.12
+
+We are happy to announce a major upgrade to the Farge service module to v0.12.
+This upgrade brings compliance with major compliance frameworks: CIS AWS V1.3, PCI-DSS V3.2, NIST-800-53, ISO27001, and SOC2.
+Additionally, we have updated our publishing process to prevent changes to the module that would violate any of these compliance frameworks.
+
+## Release Notes
+
+We made several upgrades to this module. Read further to assess any risk to upgrading your services.
+- Enabled in-transit encryption for EFS volumes.
+- Using CMK (customer-managed key) when encrypting cloudwatch logs, secrets, and image repository.
+- Enabled image scanning when an image is pushed to the image repository.
+- Enabled tag immutability on the image repository. Can only push an image once.
+
+## Upgrading
+
+
+### Database Access
+
+We released the RDS Postgres module at the same time.
+Do not perform this upgrade while upgrading an attached RDS Postgres.
+
+### Image Repository
+
+This upgrade enables encryption of your docker images.
+This requires destroying and recreating your image repository containing your docker images.
+As a result of this upgrade, your image repository will be empty.
+
+Your existing services will be unaffected, but any service restarts or redeploys will fail because the image no longer exists.
+To avoid this, build and push your latest docker image.
+```shell
+$ docker build -t my-service .
+$ nullstone push --source=my-service --app=app --env=dev
+$ nullstone deploy --app=app --env=dev
+```
+
+### Image Tag Immutability
+
+This upgrade enforces image tag immutability.
+This is a safety precaution to prevent bad actors from redeploying your app with malicious code.
+Also, image tag immutability provides easier diagnostics because it guarantees that source code did not change after build.
+This means that you will not be able to push the same image tag for an image repository more than once.
+Here is example usage that will *fail*:
+```shell
+$ docker build -t my-service .
+$ nullstone push --source=my-service --app=app --env=dev
+$ nullstone push --source=my-service --app=app --env=dev # This will fail
+```

--- a/upgrades/v0.12.md
+++ b/upgrades/v0.12.md
@@ -14,6 +14,9 @@ We made several upgrades to this module. Read further to assess any risk to upgr
 
 ## Upgrading
 
+This upgrade will cause a redeployment of the service.
+While this *will not* cause downtime, it will cause a new deployment that repeatedly fails.
+You will need to redeploy your service immediately after the upgrade. See "Image Repository" section below for more details.
 
 ### Database Access
 
@@ -30,8 +33,7 @@ Your existing services will be unaffected, but any service restarts or redeploys
 To avoid this, build and push your latest docker image.
 ```shell
 $ docker build -t my-service .
-$ nullstone push --source=my-service --app=app --env=dev
-$ nullstone deploy --app=app --env=dev
+$ nullstone launch --source=my-service --app=app --env=dev
 ```
 
 ### Image Tag Immutability


### PR DESCRIPTION
This PR sets up compliance checks and badges.

The following changes were necessary to make compliant:
* Enabled in-transit encryption for EFS volumes.
* Using CMK (customer-managed key) when encrypting cloudwatch logs, secrets, and image repository.
* Enabled image scanning when an image is pushed to the image repository.
* Enabled tag immutability on the image repository. Can only push an image once.