### PR TITLE
Fixing access to app secret encryption key

### DIFF
--- a/encryption.tf
+++ b/encryption.tf
@@ -49,4 +49,16 @@ data "aws_iam_policy_document" "encryption_key" {
       values   = ["arn:aws:logs:${data.aws_region.this.name}:${data.aws_caller_identity.current.account_id}:*"]
     }
   }
+
+  statement {
+    sid       = "Enable App Decrypt secrets"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:Decrypt"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.execution.arn]
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes access to app secrets when launching the application.

In the last upgrade, the secrets were changed to encrypt using a custom kms key.
The app was not given access to `kms:Decrypt` using that key.