### PR TITLE
Injected hosts env vars into service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
-# 0.12.0 (Apr 21, 2022)
+# 0.12.2 (May 13, 2022)
+* Added `NULLSTONE_PUBLIC_HOSTS` and `NULLSTONE_PRIVATE_HOSTS` to app env vars.
+* Fixed ECR repository being replaced on every apply due to using KMS alias instead of KMS key.
 
+# 0.12.1 (May 03, 2022)
+* Fixed access to app secrets encryption key.
+
+# 0.12.0 (Apr 21, 2022)
 * Enabled in-transit encryption for EFS volumes.
 * Using CMK (customer-managed key) when encrypting cloudwatch logs, secrets, and image repository.
 * Enabled image scanning when an image is pushed to the image repository.

--- a/outputs.tf
+++ b/outputs.tf
@@ -87,22 +87,12 @@ output "service_security_group_id" {
   description = "string ||| "
 }
 
-locals {
-  // Private and public URLs are shown in the Nullstone UI
-  // Typically, they are created through capabilities attached to the application
-  // If this module has URLs, add them here as list(string)
-  additional_private_urls = var.service_port == 0 ? [] : [
-    "http://${aws_service_discovery_service.this[0].name}.${local.service_domain}:${var.service_port}"
-  ]
-  additional_public_urls = []
-}
-
 output "private_urls" {
-  value       = concat([for url in try(local.capabilities.private_urls, []) : url["url"]], local.additional_private_urls)
+  value       = local.private_urls
   description = "list(string) ||| A list of URLs only accessible inside the network"
 }
 
 output "public_urls" {
-  value       = concat([for url in try(local.capabilities.public_urls, []) : url["url"]], local.additional_public_urls)
+  value       = local.public_urls
   description = "list(string) ||| A list of URLs accessible to the public"
 }

--- a/repository.tf
+++ b/repository.tf
@@ -17,7 +17,7 @@ resource "aws_ecr_repository" "this" {
 
   encryption_configuration {
     encryption_type = "KMS"
-    kms_key         = aws_kms_alias.this.arn
+    kms_key         = aws_kms_key.this.arn
   }
 
   count = var.service_image == "" ? 1 : 0

--- a/task.tf
+++ b/task.tf
@@ -1,6 +1,8 @@
 locals {
   standard_env_vars = tomap({
-    NULLSTONE_ENV = data.ns_workspace.this.env_name
+    NULLSTONE_ENV           = data.ns_workspace.this.env_name
+    NULLSTONE_PUBLIC_HOSTS  = join(",", local.public_hosts)
+    NULLSTONE_PRIVATE_HOSTS = join(",", local.private_hosts)
   })
 
   main_container_name = "main"

--- a/urls.tf
+++ b/urls.tf
@@ -1,0 +1,12 @@
+locals {
+  // Private and public URLs are shown in the Nullstone UI
+  // Typically, they are created through capabilities attached to the application
+  // If this module has URLs, add them here as list(string)
+  additional_private_urls = var.service_port == 0 ? [] : [
+    "http://${aws_service_discovery_service.this[0].name}.${local.service_domain}:${var.service_port}"
+  ]
+  additional_public_urls = []
+
+  private_urls = concat([for url in try(local.capabilities.private_urls, []) : url["url"]], local.additional_private_urls)
+  public_urls  = concat([for url in try(local.capabilities.public_urls, []) : url["url"]], local.additional_public_urls)
+}


### PR DESCRIPTION
- Injected `NULLSTONE_PRIVATE_HOSTS` env var into ecs service
- Injected `NULLSTONE_PUBLIC_HOSTS` env var into ecs service
- Fixed recreation of ECR repository due to using KMS alias instead of KMS key