### PR TITLE
Creating unique secret names that don't collide with deletes

### DIFF
--- a/secrets.tf
+++ b/secrets.tf
@@ -14,9 +14,13 @@ locals {
 resource "aws_secretsmanager_secret" "app_secret" {
   for_each = local.secret_keys
 
-  name       = "${local.resource_name}/${each.value}"
-  tags       = local.tags
-  kms_key_id = aws_kms_alias.this.arn
+  name_prefix = "${local.block_name}/${each.value}/"
+  tags        = local.tags
+  kms_key_id  = aws_kms_alias.this.arn
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_secretsmanager_secret_version" "app_secret" {
@@ -24,4 +28,8 @@ resource "aws_secretsmanager_secret_version" "app_secret" {
 
   secret_id     = aws_secretsmanager_secret.app_secret[each.value].id
   secret_string = local.cap_secrets[each.value]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
This changes the name of secrets in secrets manager to ensure uniqueness (especially across delete/creates).