### PR TITLE
Fixed duplicate port mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.3 (Jun 13, 2023)
+* Fixed duplicate port mappings when using sidecars.
+
 # 0.13.2 (May 30, 2023)
 * Added support for additional ports in load balancers.
 

--- a/ingress.tf
+++ b/ingress.tf
@@ -5,8 +5,8 @@ locals {
   disable_main_port_mapping = !(var.port > 0) || anytrue(values(local.sidecars_owns_service_port))
 
   cap_load_balancers   = lookup(local.capabilities, "load_balancers", [])
-  cap_port_mappings    = { for lb in local.cap_load_balancers : lb.port => { protocol = "tcp" } if lb.port != var.port }
+  cap_port_mappings    = { for lb in local.cap_load_balancers : lb.port => { protocol = "tcp" } if lb.port != tostring(var.port) }
   prelim_port_mappings = merge(tomap({ (var.port) = { protocol = "tcp" } }), local.cap_port_mappings)
   // Exclude main port from all_port_mappings if disabled
-  all_port_mappings = { for port, obj in local.prelim_port_mappings : port => obj if !(port == var.port && local.disable_main_port_mapping) }
+  all_port_mappings = { for port, obj in local.prelim_port_mappings : port => obj if !(port == tostring(var.port) && local.disable_main_port_mapping) }
 }


### PR DESCRIPTION
When using a sidecar like nginx, we exclude the port from the main container port mappings.
In a recent addition to expand port mappings, we started comparing the `port` exported from load balancers to `var.port`.
The `port` was a string and `var.port` was a number; this resulted in the comparison always being false.
This fix converts the var.port `tostring()` so that the ports correctly match.
