### PR TITLE
F/1468/cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.13.8 (Unreleased)
+# 0.13.8 (Jun 23, 2023)
 * Added optional `var.command` to override image `CMD`.
 
 # 0.13.7 (Jun 21, 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.8 (Unreleased)
+* Added optional `var.command` to override image `CMD`.
+
 # 0.13.7 (Jun 21, 2023)
 * Fixed "known after apply" for event capabilities.
 

--- a/task.tf
+++ b/task.tf
@@ -1,8 +1,10 @@
 locals {
   main_container_name = "main"
+  command             = length(var.command) > 0 ? var.command : null
 
   container_definition = {
     name      = local.main_container_name
+    command   = local.command
     image     = "${local.service_image}:${local.app_version}"
     essential = true
     portMappings = [for port, obj in local.all_port_mappings : {

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,17 @@ Use this variable to configure against docker hub, quay, etc.
 EOF
 }
 
+variable "command" {
+  type        = list(string)
+  default     = []
+  description = <<EOF
+This overrides the `CMD` specified in the image.
+Specify a blank list to use the image's `CMD`.
+Each token in the command is an item in the list.
+For example, `echo "Hello World"` would be represented as ["echo", "\"Hello World\""].
+EOF
+}
+
 variable "port" {
   type        = number
   default     = 80


### PR DESCRIPTION
Added optional `var.command` to override docker image `CMD`.